### PR TITLE
Add CORS headers only if they don't exist

### DIFF
--- a/src/org/tunepal/api/CORSResponseFilter.java
+++ b/src/org/tunepal/api/CORSResponseFilter.java
@@ -16,13 +16,15 @@ public class CORSResponseFilter implements ContainerResponseFilter
 
 		MultivaluedMap<String, Object> headers = responseContext.getHeaders();
 
-		headers.add("Access-Control-Allow-Origin", "*");
-		// headers.add("Access-Control-Allow-Origin",
-		// "http://podcastpedia.org"); //allows CORS requests only coming from
-		// podcastpedia.org
-		headers.add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
-		headers.add("Access-Control-Allow-Headers",
-				"X-Requested-With, Content-Type, X-Codingpedia");
+		if (!headers.containsKey("Access-Control-Allow-Origin")) {
+			headers.add("Access-Control-Allow-Origin", "*");
+			// headers.add("Access-Control-Allow-Origin",
+			// "http://podcastpedia.org"); //allows CORS requests only coming from
+			// podcastpedia.org
+			headers.add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
+			headers.add("Access-Control-Allow-Headers",
+					"X-Requested-With, Content-Type, X-Codingpedia");
+		}
 	}
 
 }


### PR DESCRIPTION
Currently https://tunepal.org/tunepal2/api/RandomTune returns the following HTTP headers:
```
HTTP/1.1 200 OK
Date: Thu, 13 Jun 2019 22:29:53 GMT
Server: Apache/2.4.7 (Ubuntu)
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE, PUT
Access-Control-Max-Age: 1000
Access-Control-Allow-Headers: x-requested-with, Content-Type, origin, authorization, accept, client-security-token
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, POST, DELETE, PUT
Access-Control-Allow-Headers: X-Requested-With, Content-Type, X-Codingpedia
Content-Length: 659
Keep-Alive: timeout=5, max=100
Connection: Keep-Alive
Content-Type: application/json
```

As you can see there are multiple `Access-Control-Allow-Origin`, causing the following JavaScript error:
```
Access to XMLHttpRequest at 'https://tunepal.org/tunepal2/api/RandomTune' from origin 'http://localhost:3000' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header contains multiple values '*, *', but only one is allowed.
```

This commit should fix the issue.